### PR TITLE
Add automation to trigger a Neon OS build on push to `dev`

### DIFF
--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -15,3 +15,9 @@ jobs:
     with:
       version_file: "neon_nodes/version.py"
       publish_prerelease: true
+  trigger_build:
+    uses: peter-evans/repository-dispatch@v3
+    with:
+      repository: neongeckocom/neon-os
+      event-type: release
+      client-payload: '{"ref": "dev", "repo": "neon-debos"}'


### PR DESCRIPTION
# Description
Adds build automation from https://github.com/neongeckocom/neon-os

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->