### PR TITLE
Add token to trigger NeonOS build

### DIFF
--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Call Release Action
         uses: peter-evans/repository-dispatch@v3
         with:
+          token: ${{secrets.NEON_OS_TOKEN}}
           repository: neongeckocom/neon-os
           event-type: release
           client-payload: '{"ref": "dev", "repo": "neon-debos"}'


### PR DESCRIPTION
# Description
Add token from repo secrets to allow access to neon-os automations

# Issues
Addresses test failure https://github.com/NeonGeckoCom/neon-nodes/actions/runs/8087781125/job/22100509024

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->