### PR TITLE
Handle invalid `sounds` configuration

### DIFF
--- a/neon_nodes/voice_client.py
+++ b/neon_nodes/voice_client.py
@@ -27,7 +27,7 @@
 import io
 import requests
 
-from os.path import join, dirname
+from os.path import join, dirname, isfile
 from threading import Thread, Event
 from unittest.mock import Mock
 from base64 import b64decode, b64encode
@@ -107,8 +107,13 @@ class NeonVoiceClient:
             default_file = join(dirname(__file__), "res", "start_listening.wav")
             res_file = Configuration().get('sounds', {}).get('start_listening')\
                 or default_file
-            self._listening_sound = AudioSegment.from_file(res_file,
-                                                           format="wav")
+            try:
+                self._listening_sound = AudioSegment.from_file(res_file,
+                                                               format="wav")
+            except Exception as e:
+                LOG.error(e)
+                self._listening_sound = AudioSegment.from_file(default_file,
+                                                               format="wav")
         return self._listening_sound
 
     @property
@@ -120,7 +125,13 @@ class NeonVoiceClient:
             default_file = join(dirname(__file__), "res", "error.wav")
             res_file = Configuration().get('sounds', {}).get('error') or \
                 default_file
-            self._error_sound = AudioSegment.from_file(res_file, format="wav")
+            try:
+                self._error_sound = AudioSegment.from_file(res_file,
+                                                           format="wav")
+            except Exception as e:
+                LOG.error(e)
+                self._error_sound = AudioSegment.from_file(default_file,
+                                                           format="wav")
         return self._error_sound
 
     @property

--- a/neon_nodes/voice_client.py
+++ b/neon_nodes/voice_client.py
@@ -111,7 +111,7 @@ class NeonVoiceClient:
                 self._listening_sound = AudioSegment.from_file(res_file,
                                                                format="wav")
             except Exception as e:
-                LOG.error(e)
+                LOG.error(f"Using default listening sound. e={e}")
                 self._listening_sound = AudioSegment.from_file(default_file,
                                                                format="wav")
         return self._listening_sound
@@ -129,7 +129,7 @@ class NeonVoiceClient:
                 self._error_sound = AudioSegment.from_file(res_file,
                                                            format="wav")
             except Exception as e:
-                LOG.error(e)
+                LOG.error(f"Using default error sound. e={e}")
                 self._error_sound = AudioSegment.from_file(default_file,
                                                            format="wav")
         return self._error_sound

--- a/neon_nodes/websocket_client.py
+++ b/neon_nodes/websocket_client.py
@@ -151,7 +151,7 @@ class NeonWebsocketClient:
                 self._listening_sound = AudioSegment.from_file(res_file,
                                                                format="wav")
             except Exception as e:
-                LOG.error(e)
+                LOG.error(f"Using default listening sound. e={e}")
                 self._listening_sound = AudioSegment.from_file(default_file,
                                                                format="wav")
         return self._listening_sound
@@ -169,7 +169,7 @@ class NeonWebsocketClient:
                 self._error_sound = AudioSegment.from_file(res_file,
                                                            format="wav")
             except Exception as e:
-                LOG.error(e)
+                LOG.error(f"Using default error sound. e={e}")
                 self._error_sound = AudioSegment.from_file(default_file,
                                                            format="wav")
         return self._error_sound

--- a/neon_nodes/websocket_client.py
+++ b/neon_nodes/websocket_client.py
@@ -147,8 +147,13 @@ class NeonWebsocketClient:
             default_file = join(dirname(__file__), "res", "start_listening.wav")
             res_file = Configuration().get('sounds', {}).get('start_listening')\
                 or default_file
-            self._listening_sound = AudioSegment.from_file(res_file,
-                                                           format="wav")
+            try:
+                self._listening_sound = AudioSegment.from_file(res_file,
+                                                               format="wav")
+            except Exception as e:
+                LOG.error(e)
+                self._listening_sound = AudioSegment.from_file(default_file,
+                                                               format="wav")
         return self._listening_sound
 
     @property
@@ -160,7 +165,13 @@ class NeonWebsocketClient:
             default_file = join(dirname(__file__), "res", "error.wav")
             res_file = Configuration().get('sounds', {}).get('error') or \
                 default_file
-            self._error_sound = AudioSegment.from_file(res_file, format="wav")
+            try:
+                self._error_sound = AudioSegment.from_file(res_file,
+                                                           format="wav")
+            except Exception as e:
+                LOG.error(e)
+                self._error_sound = AudioSegment.from_file(default_file,
+                                                           format="wav")
         return self._error_sound
 
     @property


### PR DESCRIPTION
# Description
Fall back to default sound files if configured files are not valid for any reason

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Addresses an observed issue with a clean neon-hub installation